### PR TITLE
Login and authentication

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,17 @@
+AllCops: 
+  TargetRubyVersion: 2.4
+
+# Metrics
+Metrics/BlockLength:
+  Exclude:
+    - !ruby/regexp /_spec\.rb$/
+
+# Style
+Style/Documentation:
+  Enabled: false
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ end
 
 gem 'active_model_serializers'
 gem 'bcrypt', '~> 3.1.7'
+gem 'jwt'
 gem 'pg', '~> 0.18'
 gem 'puma', '~> 3.7'
 gem 'rack-cors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,7 @@ GEM
     json_matchers (0.7.0)
       json-schema (~> 2.7)
     jsonapi-renderer (0.1.2)
+    jwt (1.5.6)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -225,6 +226,7 @@ DEPENDENCIES
   faker
   foreman
   json_matchers
+  jwt
   listen (>= 3.0.5, < 3.2)
   pg (~> 0.18)
   pry
@@ -251,4 +253,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.15.0
+   1.15.1

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,14 @@
+require 'tokenizer'
+
 class ApplicationController < ActionController::API
   rescue_from ActiveRecord::RecordInvalid, with: :render_record_invalid
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
 
+  before_action :authenticate_request
+
   private
+
+  attr_reader :current_user
 
   def render_record_invalid(exception)
     render json: { errors: exception.record.errors },
@@ -12,5 +18,26 @@ class ApplicationController < ActionController::API
   def render_not_found
     render json: { errors: [I18n.t(:detail, scope: 'errors.not_found')] },
            status: :not_found
+  end
+
+  def render_unauthorized
+    render json: { errors: [I18n.t(:detail, scope: 'errors.unauthorized')] },
+           status: :unauthorized
+  end
+
+  def authenticate_request
+    return render_unauthorized unless decoded_auth_token_from_headers
+    load_current_user
+  end
+
+  def decoded_auth_token_from_headers
+    return false unless request.headers['Authorization']
+    token = request.headers['Authorization'].split.last
+    @decoded_token ||= Tokenizer.decode(token)
+  end
+
+  def load_current_user
+    user_id = decoded_auth_token_from_headers[0]['payload']['user_id']
+    @current_user = User.find(user_id)
   end
 end

--- a/app/controllers/json_web_tokens_controller.rb
+++ b/app/controllers/json_web_tokens_controller.rb
@@ -1,10 +1,12 @@
-class TokensController < ApplicationController
+class JsonWebTokensController < ApplicationController
   def create
     user = User.find_by_email! token_params[:email]
 
     if user.authenticate(token_params[:password])
-      render json: 'token',
-             serializer: TokenSerializer,
+      token = JsonWebToken.new(payload: { user_id: user.id })
+      render json: token,
+             serializer: JsonWebTokenSerializer,
+             adapter: :attributes,
              status: :ok
     else
       render_not_found

--- a/app/controllers/json_web_tokens_controller.rb
+++ b/app/controllers/json_web_tokens_controller.rb
@@ -1,4 +1,6 @@
 class JsonWebTokensController < ApplicationController
+  skip_before_action :authenticate_request, only: :create
+
   def create
     user = User.find_by_email! token_params[:email]
 

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,0 +1,5 @@
+class ProfilesController < ApplicationController
+  def show
+    render json: current_user, serializer: UserSerializer, status: :ok
+  end
+end

--- a/app/controllers/tokens_controller.rb
+++ b/app/controllers/tokens_controller.rb
@@ -1,0 +1,19 @@
+class TokensController < ApplicationController
+  def create
+    user = User.find_by_email! token_params[:email]
+
+    if user.authenticate(token_params[:password])
+      render json: 'token',
+             serializer: TokenSerializer,
+             status: :ok
+    else
+      render_not_found
+    end
+  end
+
+  private
+
+  def token_params
+    params.require(:authenticate).permit(:email, :password)
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  skip_before_action :authenticate_request, only: :create
+
   def create
     user = User.create!(user_params)
     render json: user,

--- a/app/models/json_web_token.rb
+++ b/app/models/json_web_token.rb
@@ -1,0 +1,26 @@
+require 'tokenizer'
+
+class JsonWebToken
+  include ActiveModel::Serialization
+
+  def self.model_name
+    @_model_name ||= :json_web_token
+  end
+
+  def initialize(payload:, exp: 1.day.from_now)
+    @payload = payload
+    @exp = exp
+  end
+
+  def auth_token
+    @auth_token ||= Tokenizer.encode(payload: @payload.merge(claims))
+  end
+
+  private
+
+  def claims
+    {
+      exp: @exp.to_i
+    }
+  end
+end

--- a/app/serializers/json_web_token_serializer.rb
+++ b/app/serializers/json_web_token_serializer.rb
@@ -1,0 +1,3 @@
+class JsonWebTokenSerializer < ActiveModel::Serializer
+  attributes :auth_token
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   resources :users, only: [:create] do
     collection do
       resource :json_web_tokens, only: [:create], path: :login
+      resource :profile, only: [:show]
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   resources :users, only: [:create] do
     collection do
-      resource :tokens, only: [:create], path: :login
+      resource :json_web_tokens, only: [:create], path: :login
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,7 @@
 Rails.application.routes.draw do
-  resources :users, only: [:create]
+  resources :users, only: [:create] do
+    collection do
+      resource :tokens, only: [:create], path: :login
+    end
+  end
 end

--- a/lib/tokenizer.rb
+++ b/lib/tokenizer.rb
@@ -1,0 +1,12 @@
+require_relative 'tokenizer/encode'
+require_relative 'tokenizer/decode'
+
+module Tokenizer
+  def self.encode(payload)
+    Encode.call(payload)
+  end
+
+  def self.decode(token)
+    Decode.call(token)
+  end
+end

--- a/lib/tokenizer/decode.rb
+++ b/lib/tokenizer/decode.rb
@@ -1,0 +1,32 @@
+module Tokenizer
+  class Decode
+    def self.call(token)
+      new(token).decode
+    end
+
+    def initialize(token)
+      @token = token
+    end
+
+    def decode
+      JWT.decode(@token,
+                 Rails.application.secrets.secret_key_base,
+                 true,
+                 decode_options)
+    rescue JWT::DecodeError
+      false
+    end
+
+    private
+
+    def decode_options
+      {
+        algorithm: 'HS256',
+        iss: 'astronomania-api',
+        verify_iss: true,
+        aud: 'web-client',
+        verify_aud: true
+      }
+    end
+  end
+end

--- a/lib/tokenizer/encode.rb
+++ b/lib/tokenizer/encode.rb
@@ -1,0 +1,31 @@
+module Tokenizer
+  class Encode
+    def self.call(payload)
+      new(payload).encode
+    end
+
+    def initialize(payload)
+      @payload = payload
+    end
+
+    def encode
+      JWT.encode(@payload.merge(claims),
+                 Rails.application.secrets.secret_key_base,
+                 'HS256')
+    end
+
+    private
+
+    def claims
+      {
+        iss: 'astronomania-api',
+        aud: 'web-client',
+        exp: token_expiration
+      }
+    end
+
+    def token_expiration
+      @payload[:exp] || 1.day.from_now.to_i
+    end
+  end
+end

--- a/spec/lib/tokenizer/decode_spec.rb
+++ b/spec/lib/tokenizer/decode_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+require 'tokenizer'
+
+describe Tokenizer::Decode do
+  let :valid_payload do
+    {
+      iss: 'astronomania-api',
+      aud: 'web-client',
+      exp: 1.day.from_now.to_i,
+      user_id: 1
+    }
+  end
+
+  context 'valid token' do
+    let :encoded_jwt do
+      JWT.encode(valid_payload,
+                 Rails.application.secrets.secret_key_base,
+                 'HS256')
+    end
+
+    subject do
+      described_class.call(encoded_jwt)
+    end
+
+    it 'returns the decoded token' do
+      expect(subject[0]['user_id']).to eq 1
+    end
+  end
+
+  context 'expired token' do
+    let :payload do
+      valid_payload.merge exp: 1.day.ago
+    end
+
+    let :encoded_jwt do
+      JWT.encode(payload,
+                 Rails.application.secrets.secret_key_base,
+                 'HS256')
+    end
+
+    subject do
+      described_class.call(encoded_jwt)
+    end
+
+    it 'returns the decoded token' do
+      expect(subject).to be false
+    end
+  end
+
+  context 'incorrect issuer claim' do
+    let :payload do
+      valid_payload.merge iss: 'some other api'
+    end
+
+    let :encoded_jwt do
+      JWT.encode(payload,
+                 Rails.application.secrets.secret_key_base,
+                 'HS256')
+    end
+
+    subject do
+      described_class.call(encoded_jwt)
+    end
+
+    it 'returns the decoded token' do
+      expect(subject).to be false
+    end
+  end
+
+  context 'incorrect audience claim' do
+    let :payload do
+      valid_payload.merge aud: 'some other audience'
+    end
+
+    let :encoded_jwt do
+      JWT.encode(payload,
+                 Rails.application.secrets.secret_key_base,
+                 'HS256')
+    end
+
+    subject do
+      described_class.call(encoded_jwt)
+    end
+
+    it 'returns the decoded token' do
+      expect(subject).to be false
+    end
+  end
+end

--- a/spec/lib/tokenizer/encode_spec.rb
+++ b/spec/lib/tokenizer/encode_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+require 'tokenizer'
+
+describe Tokenizer::Encode do
+  context 'payload without exp' do
+    let :payload do
+      {
+        user_id: 1
+      }
+    end
+
+    it 'returns a JWT' do
+      expect(described_class.call(payload)).to match(/\Aey/)
+    end
+  end
+
+  context 'payload with exp' do
+    let :payload do
+      {
+        user_id: 1,
+        exp: 7.days.from_now
+      }
+    end
+
+    it 'returns a JWT' do
+      expect(described_class.call(payload)).to match(/\Aey/)
+    end
+  end
+end

--- a/spec/models/json_web_token_spec.rb
+++ b/spec/models/json_web_token_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe JsonWebToken do
+  describe '#initialize' do
+    it 'does not raise an exception' do
+      expect do
+        described_class.new(payload: { user_id: 1 })
+      end.to_not raise_exception
+    end
+  end
+
+  describe '#auth_token' do
+    context 'default exp' do
+      subject do
+        described_class.new(payload: { user_id: 1 })
+      end
+
+      it 'returns a JWT' do
+        expect(subject.auth_token).to match(/\Aey/)
+      end
+    end
+
+    context 'with optional exp argument' do
+      subject do
+        described_class.new(payload: { user_id: 1 }, exp: 7.days.from_now)
+      end
+
+      it 'returns and JWT' do
+        expect(subject.auth_token).to match(/\Aey/)
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,5 +20,5 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
-  config.include JsonHelpers, type: :request
+  config.include ApiHelpers, type: :request
 end

--- a/spec/requests/json_web_tokens/user_login_spec.rb
+++ b/spec/requests/json_web_tokens/user_login_spec.rb
@@ -14,7 +14,7 @@ describe 'User logs in' do
     end
 
     before :each do
-      post tokens_path,
+      post json_web_tokens_path,
            params: valid_credentials,
            as: :json
     end
@@ -24,9 +24,11 @@ describe 'User logs in' do
     end
 
     it 'reponds with the token API schema' do
+      expect(response).to match_response_schema('auth_token')
     end
 
     it 'responds with an auth token' do
+      expect(json['auth_token']).to_not be nil
     end
   end
 
@@ -41,7 +43,7 @@ describe 'User logs in' do
     end
 
     it 'responds with 404 status' do
-      post tokens_path, params: invalid_credentials, as: :json
+      post json_web_tokens_path, params: invalid_credentials, as: :json
 
       expect(response).to have_http_status :not_found
     end
@@ -58,7 +60,7 @@ describe 'User logs in' do
     end
 
     it 'responds with 404 status' do
-      post tokens_path, params: invalid_credentials, as: :json
+      post json_web_tokens_path, params: invalid_credentials, as: :json
 
       expect(response).to have_http_status :not_found
     end

--- a/spec/requests/profiles/profiles_spec.rb
+++ b/spec/requests/profiles/profiles_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe 'profiles' do
+  let :user do
+    create :user
+  end
+
+  describe 'user gets their profile' do
+    context 'without auth token' do
+      it 'responds with 401 status' do
+        get profile_path
+
+        expect(response).to have_http_status(401)
+      end
+    end
+
+    context 'with invalid auth token' do
+      it 'responds with 401 status' do
+        get profile_path, headers: { 'Authorization': 'Bearer fake_token' }
+
+        expect(response).to have_http_status(401)
+      end
+    end
+
+    context 'with valid auth token' do
+      before :each do
+        get profile_path, headers: authenticated_headers(user)
+      end
+
+      it 'responds with 200 status' do
+        expect(response).to have_http_status :ok
+      end
+    end
+  end
+end

--- a/spec/requests/tokens/user_login_spec.rb
+++ b/spec/requests/tokens/user_login_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+describe 'User logs in' do
+  let :user { create :user }
+
+  context 'with valid credentials' do
+    let :valid_credentials do
+      {
+        authenticate: {
+          email: user.email,
+          password: user.password
+        }
+      }
+    end
+
+    before :each do
+      post tokens_path,
+           params: valid_credentials,
+           as: :json
+    end
+
+    it 'responds with 200 status' do
+      expect(response).to have_http_status :ok
+    end
+
+    it 'reponds with the token API schema' do
+    end
+
+    it 'responds with an auth token' do
+    end
+  end
+
+  context 'with invalid email' do
+    let :invalid_credentials do
+      {
+        authenticate: {
+          email: 'fake@example.com',
+          password: 'aintreal'
+        }
+      }
+    end
+
+    it 'responds with 404 status' do
+      post tokens_path, params: invalid_credentials, as: :json
+
+      expect(response).to have_http_status :not_found
+    end
+  end
+
+  context 'with valid email and bad password' do
+    let :invalid_credentials do
+      {
+        authenticate: {
+          email: user.email,
+          password: '!@$^typo!'
+        }
+      }
+    end
+
+    it 'responds with 404 status' do
+      post tokens_path, params: invalid_credentials, as: :json
+
+      expect(response).to have_http_status :not_found
+    end
+  end
+end

--- a/spec/support/api/schemas/auth_token.json
+++ b/spec/support/api/schemas/auth_token.json
@@ -1,0 +1,9 @@
+{
+  "type": "object",
+  "required": ["auth_token"],
+  "properties": {
+    "auth_token": {
+      "type": "string"
+    }
+  }
+}

--- a/spec/support/helpers/api_helpers.rb
+++ b/spec/support/helpers/api_helpers.rb
@@ -1,0 +1,10 @@
+module ApiHelpers
+  def json
+    JSON.parse response.body
+  end
+
+  def authenticated_headers(user)
+    jwt = JsonWebToken.new(payload: { user_id: user.id })
+    { 'Authorization': "Beaer #{jwt.auth_token}" }
+  end
+end

--- a/spec/support/helpers/json_helpers.rb
+++ b/spec/support/helpers/json_helpers.rb
@@ -1,5 +1,0 @@
-module JsonHelpers
-  def json
-    JSON.parse response.body
-  end
-end


### PR DESCRIPTION
- Write `Tokenizer` module, a wrapper for `jwt` to encode and decode tokens
- render `auth_token` on successful user authentication with email and password
- Create `authenticate_request` method to be used with as a `before_action` filter to authenticate resources with a token
- skip `authenticate request` for creating a user and requesting an auth token