### PR TITLE
Asteroid index

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,3 +24,7 @@ Style/FrozenStringLiteralComment:
 
 Style/StringLiterals:
   Enabled: false
+
+Style/SymbolArray:
+  Enabled: true
+  MinSize: 8

--- a/app/controllers/asteroids/near_earth_objects_controller.rb
+++ b/app/controllers/asteroids/near_earth_objects_controller.rb
@@ -1,0 +1,13 @@
+module Asteroids
+  class NearEarthObjectsController < ApplicationController
+    skip_before_action :authenticate_request, only: [:index]
+
+    def index
+      neos = Asteroid::NearEarthObject.all
+      render json: neos,
+             each_serializer: Asteroids::NearEarthObjectSerializer,
+             root: :near_earth_objects,
+             status: :ok
+    end
+  end
+end

--- a/app/controllers/asteroids/near_earth_objects_controller.rb
+++ b/app/controllers/asteroids/near_earth_objects_controller.rb
@@ -3,7 +3,7 @@ module Asteroids
     skip_before_action :authenticate_request, only: [:index, :show]
 
     def index
-      neos = Asteroid::NearEarthObject.all
+      neos = Paginate.new(Asteroid::NearEarthObject.all, params).perform
 
       render json: neos,
              each_serializer: Asteroids::NearEarthObjectSerializer,

--- a/app/controllers/asteroids/near_earth_objects_controller.rb
+++ b/app/controllers/asteroids/near_earth_objects_controller.rb
@@ -1,11 +1,20 @@
 module Asteroids
   class NearEarthObjectsController < ApplicationController
-    skip_before_action :authenticate_request, only: [:index]
+    skip_before_action :authenticate_request, only: [:index, :show]
 
     def index
       neos = Asteroid::NearEarthObject.all
+
       render json: neos,
              each_serializer: Asteroids::NearEarthObjectSerializer,
+             status: :ok
+    end
+
+    def show
+      neo = Asteroid::NearEarthObject.find params[:id]
+
+      render json: neo,
+             serializer: Asteroids::NearEarthObjectSerializer,
              status: :ok
     end
   end

--- a/app/controllers/asteroids/near_earth_objects_controller.rb
+++ b/app/controllers/asteroids/near_earth_objects_controller.rb
@@ -6,7 +6,6 @@ module Asteroids
       neos = Asteroid::NearEarthObject.all
       render json: neos,
              each_serializer: Asteroids::NearEarthObjectSerializer,
-             root: :near_earth_objects,
              status: :ok
     end
   end

--- a/app/queries/paginate.rb
+++ b/app/queries/paginate.rb
@@ -1,0 +1,25 @@
+class Paginate
+  attr_reader :relation, :per, :page
+
+  def initialize(relation, params = {})
+    @relation = relation
+    @page = params.fetch(:page, 1).to_i
+    @per = params.fetch(:per, 20).to_i
+  end
+
+  def perform
+    relation.offset(offset_by).limit(limit_by)
+  end
+
+  private
+
+  def offset_by
+    return 0 if page <= 1
+    (page - 1) * limit_by
+  end
+
+  def limit_by
+    return 20 unless (1..20).cover? per
+    per
+  end
+end

--- a/app/serializers/asteroids/near_earth_object_serializer.rb
+++ b/app/serializers/asteroids/near_earth_object_serializer.rb
@@ -1,0 +1,6 @@
+module Asteroids
+  class NearEarthObjectSerializer < ActiveModel::Serializer
+    has_one :orbit, class_name: 'Asteroid::Orbit'
+    has_many :close_approaches, class_name: 'Asteroid::CloseApproach'
+  end
+end

--- a/config/initializers/serializers.rb
+++ b/config/initializers/serializers.rb
@@ -1,1 +1,2 @@
-ActiveModel::Serializer.config.adapter = :json
+ActiveModel::Serializer.config.adapter = :json_api
+ActiveModelSerializers.config.key_transform = :unaltered

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,6 @@ Rails.application.routes.draw do
   end
 
   namespace :asteroids do
-    resources :near_earth_objects, only: [:index]
+    resources :near_earth_objects, only: [:index, :show]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,8 @@ Rails.application.routes.draw do
   namespace :admin do
     resource :jobs, only: [:create]
   end
+
+  namespace :asteroids do
+    resources :near_earth_objects, only: [:index]
+  end
 end

--- a/spec/factories/asteroid/near_earth_objects.rb
+++ b/spec/factories/asteroid/near_earth_objects.rb
@@ -23,11 +23,24 @@ FactoryGirl.define do
         "estimated_diameter_max" => 12303.3967781592
       }
     )
-    after :create do |near_earth_object|
-      create :asteroid_orbit, near_earth_object: near_earth_object
-      create_list :asteroid_close_approach,
-                  2,
-                  near_earth_object: near_earth_object
+    # after :create do |near_earth_object|
+    #   create :asteroid_orbit, near_earth_object: near_earth_object
+    #   create_list :asteroid_close_approach,
+    #               2,
+    #               near_earth_object: near_earth_object
+    # end
+    trait :with_orbit do
+      after :create do |near_earth_object|
+        create :asteroid_orbit, near_earth_object: near_earth_object
+      end
+    end
+
+    trait :with_close_approaches do
+      after :create do |near_earth_object|
+        create_list(:asteroid_close_approach,
+                    2,
+                    near_earth_object: near_earth_object)
+      end
     end
   end
 end

--- a/spec/factories/asteroid/near_earth_objects.rb
+++ b/spec/factories/asteroid/near_earth_objects.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :asteroid_near_earth_object, class: 'Asteroid::NearEarthObject' do
-    neo_reference_id '2021277'
+    sequence(:neo_reference_id) { |n| "2021277-#{n}" }
     name '21277 (1996 TO5)'
     nasa_jpl_url 'http://ssd.jpl.nasa.gov/sbdb.cgi?sstr=2021277'
     absolute_magnitude_h 16.0

--- a/spec/factories/asteroid/near_earth_objects.rb
+++ b/spec/factories/asteroid/near_earth_objects.rb
@@ -23,5 +23,11 @@ FactoryGirl.define do
         "estimated_diameter_max" => 12303.3967781592
       }
     )
+    after :create do |near_earth_object|
+      create :asteroid_orbit, near_earth_object: near_earth_object
+      create_list :asteroid_close_approach,
+                  2,
+                  near_earth_object: near_earth_object
+    end
   end
 end

--- a/spec/factories/asteroid/near_earth_objects.rb
+++ b/spec/factories/asteroid/near_earth_objects.rb
@@ -23,12 +23,7 @@ FactoryGirl.define do
         "estimated_diameter_max" => 12303.3967781592
       }
     )
-    # after :create do |near_earth_object|
-    #   create :asteroid_orbit, near_earth_object: near_earth_object
-    #   create_list :asteroid_close_approach,
-    #               2,
-    #               near_earth_object: near_earth_object
-    # end
+
     trait :with_orbit do
       after :create do |near_earth_object|
         create :asteroid_orbit, near_earth_object: near_earth_object

--- a/spec/queries/paginate_spec.rb
+++ b/spec/queries/paginate_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+describe Paginate do
+  before :all do
+    create_list :asteroid_near_earth_object, 41
+  end
+
+  after :all do
+    Asteroid::NearEarthObject.destroy_all
+  end
+
+  let :relation do
+    Asteroid::NearEarthObject.all
+  end
+
+  let :first_twenty_ids do
+    Asteroid::NearEarthObject.offset(0).limit(20).ids
+  end
+
+  context 'without options' do
+    subject do
+      described_class.new(relation).perform
+    end
+
+    it 'returns the first twenty records' do
+      expect(subject.ids).to contain_exactly(*first_twenty_ids)
+    end
+  end
+
+  context 'when options are nil' do
+    subject do
+      described_class.new(relation, per: nil, page: nil).perform
+    end
+
+    it 'returns the first twenty records' do
+      expect(subject.ids).to contain_exactly(*first_twenty_ids)
+    end
+  end
+
+  context 'when options are empty strings' do
+    subject do
+      described_class.new(relation, per: '', page: '').perform
+    end
+
+    it 'returns the first twenty records' do
+      expect(subject.ids).to contain_exactly(*first_twenty_ids)
+    end
+  end
+
+  context 'when per option is greater than 20' do
+    subject do
+      described_class.new(relation, per: 100, page: 2).perform
+    end
+
+    let :ids do
+      Asteroid::NearEarthObject.offset(20).limit(20).ids
+    end
+
+    it 'respects the requested page number but defaults to 20 records' do
+      expect(subject.ids).to contain_exactly(*ids)
+    end
+  end
+
+  context 'when page option exceeds the actual number of pages' do
+    subject do
+      described_class.new(relation, per: 20, page: 4).perform
+    end
+
+    it 'is empty' do
+      expect(subject).to be_empty
+    end
+  end
+
+  context 'when options are 5 per page starting at page 2' do
+    subject do
+      described_class.new(relation, per: 5, page: 2).perform
+    end
+
+    let :ids do
+      Asteroid::NearEarthObject.offset(5).limit(5).ids
+    end
+
+    it 'returns the 2nd set of 5 records' do
+      expect(subject.ids).to contain_exactly(*ids)
+    end
+  end
+end

--- a/spec/requests/asteroids/asteroids_index_spec.rb
+++ b/spec/requests/asteroids/asteroids_index_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe 'Asteroid Index' do
+  before :all do
+    21.times { create :asteroid_near_earth_object }
+  end
+
+  context 'without pagination' do
+    before :each do
+      get asteroids_near_earth_objects_path
+    end
+
+    it 'returns 20 asteroids by default' do
+      expect(json['near_earth_objects'].count).to eq 20
+    end
+  end
+end

--- a/spec/requests/asteroids/asteroids_index_spec.rb
+++ b/spec/requests/asteroids/asteroids_index_spec.rb
@@ -5,6 +5,10 @@ describe 'Asteroid Index' do
     21.times { create :asteroid_near_earth_object }
   end
 
+  after :all do
+    Asteroid::NearEarthObject.destroy_all
+  end
+
   context 'without pagination' do
     before :each do
       get asteroids_near_earth_objects_path

--- a/spec/requests/asteroids/asteroids_index_spec.rb
+++ b/spec/requests/asteroids/asteroids_index_spec.rb
@@ -15,7 +15,7 @@ describe 'Asteroid Index' do
     end
 
     it 'returns 20 asteroids by default' do
-      expect(json['near_earth_objects'].count).to eq 20
+      expect(json['data'].count).to eq 20
     end
   end
 end

--- a/spec/requests/asteroids/near_earth_object_show_spec.rb
+++ b/spec/requests/asteroids/near_earth_object_show_spec.rb
@@ -15,7 +15,6 @@ describe 'Asteroid::NearEarthObject #show' do
     end
 
     it 'responds with near_earth_object JSON' do
-      p json
       expect(response).to match_response_schema('asteroid_near_earth_object')
     end
   end

--- a/spec/requests/asteroids/near_earth_object_show_spec.rb
+++ b/spec/requests/asteroids/near_earth_object_show_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe 'Asteroid::NearEarthObject #show' do
+  let :near_earth_object do
+    create :asteroid_near_earth_object
+  end
+
+  context 'valid neo_reference_id' do
+    before :each do
+      get asteroids_near_earth_object_path(near_earth_object)
+    end
+
+    it 'responds with 200 status' do
+      expect(response).to have_http_status :ok
+    end
+
+    it 'responds with near_earth_object JSON' do
+      expect(response).to match_response_schema('asteroid_near_earth_object')
+    end
+  end
+
+  context 'invalid neo_reference_id' do
+    it 'responds with 404 status' do
+      get asteroids_near_earth_object_path(id: 'non-existent')
+
+      expect(response).to have_http_status :not_found
+    end
+  end
+end

--- a/spec/requests/asteroids/near_earth_object_show_spec.rb
+++ b/spec/requests/asteroids/near_earth_object_show_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe 'Asteroid::NearEarthObject #show' do
   let :near_earth_object do
-    create :asteroid_near_earth_object
+    create :asteroid_near_earth_object, :with_orbit, :with_close_approaches
   end
 
   context 'valid neo_reference_id' do
@@ -15,6 +15,7 @@ describe 'Asteroid::NearEarthObject #show' do
     end
 
     it 'responds with near_earth_object JSON' do
+      p json
       expect(response).to match_response_schema('asteroid_near_earth_object')
     end
   end

--- a/spec/requests/asteroids/near_earth_objects_index_spec.rb
+++ b/spec/requests/asteroids/near_earth_objects_index_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe 'Asteroid Index' do
   before :all do
-    21.times { create :asteroid_near_earth_object }
+    create_list :asteroid_near_earth_object, 21
   end
 
   after :all do

--- a/spec/requests/users/users_spec.rb
+++ b/spec/requests/users/users_spec.rb
@@ -24,7 +24,7 @@ describe 'Users API' do
       end
 
       it 'responds with the user id' do
-        expect(json['user']['id']).to eq created_user.id
+        expect(json['data']['id']).to eq created_user.id.to_s
       end
     end
 

--- a/spec/support/api/schemas/asteroid_near_earth_object.json
+++ b/spec/support/api/schemas/asteroid_near_earth_object.json
@@ -1,0 +1,28 @@
+{
+  "type": "object",
+  "required": ["data"],
+  "properties": {
+    "id": { "type": "string" },
+    "type": { "type": "string" },
+    "attributes": {
+      "type": "object",
+      "required": [],
+      "properties": {
+      }
+    },
+    "relationships": {
+      "type": "object",
+      "required": ["obrit", "close_approaches"],
+      "properties": {
+        "orbit": {
+          "type": "object",
+          "item": { "$ref": "asteroid_orbit.json"}
+        },
+        "close_approaches": {
+          "type": "array"
+        }
+      }
+    }
+  }
+}
+

--- a/spec/support/api/schemas/asteroid_near_earth_object.json
+++ b/spec/support/api/schemas/asteroid_near_earth_object.json
@@ -2,27 +2,33 @@
   "type": "object",
   "required": ["data"],
   "properties": {
-    "id": { "type": "string" },
-    "type": { "type": "string" },
-    "attributes": {
+    "data": {
       "type": "object",
-      "required": [],
+      "required": ["id", "type", "relationships"],
       "properties": {
-      }
-    },
-    "relationships": {
-      "type": "object",
-      "required": ["obrit", "close_approaches"],
-      "properties": {
-        "orbit": {
+        "id": { "type": "string" },
+        "type": { "type": "string" },
+        "relationships": {
           "type": "object",
-          "item": { "$ref": "asteroid_orbit.json"}
-        },
-        "close_approaches": {
-          "type": "array"
+          "required": ["orbit", "close_approaches"],
+          "properties": {
+            "orbit": {
+              "type": "object",
+              "required": ["data"],
+              "properties": {
+                "data": { "type": "object" }
+              }
+            },
+            "close_approaches": {
+              "type": "object",
+              "required": ["data"],
+              "properties": {
+                "data": { "type": "array" }
+              }
+            }
+          }
         }
       }
     }
   }
 }
-

--- a/spec/support/api/schemas/user.json
+++ b/spec/support/api/schemas/user.json
@@ -1,15 +1,15 @@
 {
   "type": "object",
-  "required": ["user"],
+  "required": ["data"],
   "properties": {
-    "user": {
+    "id": { "type": "integer" },
+    "type": { "type": "string" },
+    "attributes": {
       "type": "object",
       "required": [
-        "id",
         "email"
       ],
       "properties": {
-        "id": { "type": "integer" },
         "email": { "type": "string" }
       }
     }

--- a/spec/support/api/schemas/user.json
+++ b/spec/support/api/schemas/user.json
@@ -2,15 +2,19 @@
   "type": "object",
   "required": ["data"],
   "properties": {
-    "id": { "type": "integer" },
-    "type": { "type": "string" },
-    "attributes": {
+    "data": {
       "type": "object",
-      "required": [
-        "email"
-      ],
+      "required": ["id", "type", "attributes"],
       "properties": {
-        "email": { "type": "string" }
+        "id": { "type": "string" },
+        "type": { "type": "string" },
+        "attributes": {
+          "type": "object",
+          "required": ["email"],
+          "properties": {
+            "email": { "type": "string" }
+          }
+        }
       }
     }
   }

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -3,4 +3,10 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.clean_with(:truncation)
   end
+
+  config.around(:each) do |example|
+    DatabaseCleaner.cleaning do
+      example.run
+    end
+  end
 end


### PR DESCRIPTION
- Add `:index` and `:show` actions for `NearEarthObjectsController`
- Include `Paginate` query object.  Max records per request is set to 20.
- Switch serializer adapter to `json_api` since this will be a public API