### PR TITLE
Add Apod controller, serializer and route to show action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@
 
 # Ignore node_modules
 node_modules
+
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml

--- a/app/controllers/apods_controller.rb
+++ b/app/controllers/apods_controller.rb
@@ -1,0 +1,8 @@
+class ApodsController < ApplicationController
+  def show
+    apod = Apod.latest
+    render json: apod,
+           serializer: ApodSerializer,
+           status: :ok
+  end
+end

--- a/app/models/apod.rb
+++ b/app/models/apod.rb
@@ -1,3 +1,5 @@
 class Apod < ApplicationRecord
   validates :date, :explanation, :title, :url, presence: true
+
+  scope :latest, -> { order(date: :desc).first }
 end

--- a/app/serializers/apod_serializer.rb
+++ b/app/serializers/apod_serializer.rb
@@ -1,0 +1,9 @@
+class ApodSerializer < ActiveModel::Serializer
+  attributes :copyright,
+             :date,
+             :explanation,
+             :hdurl,
+             :media_type,
+             :title,
+             :url
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,4 +14,6 @@ Rails.application.routes.draw do
     resources :near_earth_objects, only: [:index, :show]
     resource :stats, only: [:show], controller: :near_earth_objects_stats
   end
+
+  resource :apod, only: [:show]
 end

--- a/spec/models/apod_spec.rb
+++ b/spec/models/apod_spec.rb
@@ -11,4 +11,15 @@ describe Apod do
     it { is_expected.to validate_presence_of :title }
     it { is_expected.to validate_presence_of :url }
   end
+
+  describe 'scopes' do
+    describe '.latest' do
+      it 'returns the most recent Apod' do
+        create :apod, date: Date.today
+        create :apod, date: Date.yesterday
+
+        expect(described_class.latest.date).to eq Date.today
+      end
+    end
+  end
 end

--- a/spec/requests/apods/apod_spec.rb
+++ b/spec/requests/apods/apod_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe 'requests for apods' do
+  describe '#show' do
+    before :each do
+      create :apod, date: Date.today
+      create :apod, date: Date.yesterday
+      get apod_path
+    end
+    it 'responds with 200 status' do
+      expect(response).to have_http_status :ok
+    end
+
+    it 'responds with apod JSON' do
+      expect(response).to match_response_schema 'apod'
+    end
+
+    it 'returns the latest apod' do
+      expect(json_attrs['date']).to eq Date.today.to_s
+    end
+  end
+end

--- a/spec/support/api/schemas/apod.json
+++ b/spec/support/api/schemas/apod.json
@@ -1,0 +1,35 @@
+{
+  "type": "object",
+  "required": ["data"],
+  "properties": {
+    "data": {
+      "type": "object",
+      "required": ["id", "type", "attributes"],
+      "properties": {
+        "id": { "type": "string" },
+        "type": { "type": "string" },
+        "attributes": {
+          "type": "object",
+          "required": [
+            "copyright",
+            "date",
+            "explanation",
+            "hdurl",
+            "media_type",
+            "title",
+            "url"]
+          ,
+          "properties": {
+            "copyright": { "type": "string" },
+            "date": { "type": "string" },
+            "explanation": { "type": "string" },
+            "hdurl": { "type": "string" },
+            "media_type": { "type": "string" },
+            "title": { "type": "string" },
+            "url": { "type": "string" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/helpers/api_helpers.rb
+++ b/spec/support/helpers/api_helpers.rb
@@ -3,6 +3,10 @@ module ApiHelpers
     JSON.parse response.body
   end
 
+  def json_attrs
+    json['data']['attributes']
+  end
+
   def authenticated_headers(user)
     jwt = JsonWebToken.new(payload: { user_id: user.id })
     { 'Authorization': "Beaer #{jwt.auth_token}" }


### PR DESCRIPTION
- `/apod` endpoint returns the Astronomy Picture of the Day